### PR TITLE
Nav bar adjustments

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -73,36 +73,25 @@ class MakersBnB < Sinatra::Base
     redirect '/members_area'
   end
 
-  get '/add_form' do
+  get '/spaces/create' do
     erb :add_form
   end
 
   post '/spaces/create' do
     Space.create(
-      user_id: params[:user_id],
+      user_id: session[:current_user].id,
       name: params[:name],
       info: params[:info],
       location: params[:location],
       price: params[:price]
       )
-
-    space = Space.find_by(name: params[:name])
-
-    Availability.create(
-      space_id: space.id,
-      date: params[:date]
-      )
-
       flash[:notice] = "Space successfully added"
-
-    redirect '/'
+    redirect '/members_area'
   end
 
   post '/spaces/update' do
     space = Space.find_by(id: session[:space_id])
     space_user_id = space.user_id
-    p space_user_id
-    p session[:current_user].id
     if session[:current_user].id == space_user_id
       Availability.create(
         space_id: space.id,
@@ -116,6 +105,9 @@ class MakersBnB < Sinatra::Base
   get '/space/:id' do
     session[:space_id] = params[:id]
     @space = Space.find_or_initialize_by(id: session[:space_id])
+    if session[:current_user] != nil
+      @real_owner = true if @space.user_id == session[:current_user].id
+    end
     @available_dates = @space.availabilities.map { |a| a.date }
     erb :space
   end

--- a/app.rb
+++ b/app.rb
@@ -50,6 +50,11 @@ class MakersBnB < Sinatra::Base
     redirect '/signup'
   end
 
+  post '/sign_out' do
+    session[:current_user] = nil
+    redirect '/'
+  end
+
   get '/login' do
     erb :login
   end

--- a/spec/features/add_availability_spec.rb
+++ b/spec/features/add_availability_spec.rb
@@ -1,22 +1,14 @@
 feature 'Add space availability' do
 
-  # add spec tests for logged in users and delete current
-  scenario 'Logged in users can add new space with availability' do
+  scenario 'Logged in users can add more availability to their spaces' do
     visit('/')
     add_first_user_and_confirm
     add_first_space_and_confirm
 
-
-    expect(page).to have_content("Space successfully added")
-  end
-
-  scenario 'Logged in users can add more availability to their spaces' do
-    visit('/')
-
-    add_first_space_and_confirm
     add_extra_availability_and_confirm
 
     expect(page).to have_content("Date successfully added to Space")
+    expect(page).to have_content("2018-12-10")
   end
 
 end

--- a/spec/features/add_availability_spec.rb
+++ b/spec/features/add_availability_spec.rb
@@ -1,15 +1,16 @@
 feature 'Add space availability' do
 
   # add spec tests for logged in users and delete current
-  scenario 'space-owners can add new space with availability' do
+  scenario 'Logged in users can add new space with availability' do
     visit('/')
-
+    add_first_user_and_confirm
     add_first_space_and_confirm
+
 
     expect(page).to have_content("Space successfully added")
   end
 
-  scenario 'space-owners can add more availability to their spaces' do
+  scenario 'Logged in users can add more availability to their spaces' do
     visit('/')
 
     add_first_space_and_confirm

--- a/spec/features/create_space_spec.rb
+++ b/spec/features/create_space_spec.rb
@@ -1,6 +1,7 @@
 feature 'Create spaces' do
   scenario 'Logged in user can add a space' do
     visit('/')
+    add_first_user_and_confirm
     # log in
 
     add_first_space_and_confirm

--- a/spec/features/create_space_spec.rb
+++ b/spec/features/create_space_spec.rb
@@ -2,7 +2,6 @@ feature 'Create spaces' do
   scenario 'Logged in user can add a space' do
     visit('/')
     add_first_user_and_confirm
-    # log in
 
     add_first_space_and_confirm
 

--- a/spec/features/list_owner_spaces.rb
+++ b/spec/features/list_owner_spaces.rb
@@ -1,0 +1,8 @@
+# feature 'List owner spaces' do
+#   scenario 'Logged in user can view own spaces on membership page' do
+#     visit('/')
+#     add_first_user_and_confirm
+#     #
+#     expect(page).to have_content "Samir's Super Shack"
+#     expect(page).to have_content "Harry's Happy House"
+#   end

--- a/spec/features/list_space_spec.rb
+++ b/spec/features/list_space_spec.rb
@@ -1,20 +1,37 @@
-feature 'Show spaces' do
-  scenario 'Users can see all spaces' do
+feature 'List spaces' do
+  scenario 'Logged in users can see all spaces' do
     visit('/')
+    add_first_user_and_confirm
     add_first_space_and_confirm
     add_second_space_and_confirm
+    click_link "Home"
 
     expect(page).to have_content "Samir's Super Shack"
-    expect(page).to have_content "Harry's Happy House"
-  end
-
-  scenario 'Users can see details of all spaces' do
-    visit('/')
-    add_first_space_and_confirm
-    add_second_space_and_confirm
-
     expect(page).to have_content "Price: 1000000"
     expect(page).to have_content "Info: 1 room, 1 bed, not great tbh"
     expect(page).to have_content "Middle of nowhere"
+
+    expect(page).to have_content "Harry's Happy House"
+    expect(page).to have_content "Price: 5000"
+    expect(page).to have_content "Info: 20 room, 1 bed, a work in progress"
+    expect(page).to have_content "Right here"
+  end
+
+  scenario 'Non-logged in users can see all spaces' do
+    visit('/')
+    add_first_user_and_confirm
+    add_first_space_and_confirm
+    add_second_space_and_confirm
+    click_link "Sign Out"
+
+    expect(page).to have_content "Samir's Super Shack"
+    expect(page).to have_content "Price: 1000000"
+    expect(page).to have_content "Info: 1 room, 1 bed, not great tbh"
+    expect(page).to have_content "Middle of nowhere"
+
+    expect(page).to have_content "Harry's Happy House"
+    expect(page).to have_content "Price: 5000"
+    expect(page).to have_content "Info: 20 room, 1 bed, a work in progress"
+    expect(page).to have_content "Right here"
   end
 end

--- a/spec/features/log_in_spec.rb
+++ b/spec/features/log_in_spec.rb
@@ -1,5 +1,4 @@
 feature 'Log in' do
-
   scenario 'User can log in' do
     visit '/'
     add_first_user_and_confirm
@@ -10,10 +9,10 @@ feature 'Log in' do
     fill_in :password, with: 'password1'
     click_button 'Submit'
 
-    expect(page).to have_content('Hello, Samir')
+    expect(page).to have_content('Welcome, Lazy')
   end
 
-  scenario 'does not allow user to login with incorrect details' do
+  scenario 'Does not allow user to login with incorrect details' do
     visit '/'
     add_first_user_and_confirm
     click_link 'Sign Out'
@@ -21,7 +20,9 @@ feature 'Log in' do
     click_link 'Login'
     fill_in :handle, with: 'Lazy2'
     fill_in :password, with: 'password2'
+    click_button 'Submit'
+
     expect(page).to have_content('No details held')
-    expect(current_path).to be('/login')
+    expect(current_path).to eq('/login')
   end
 end

--- a/spec/features/log_in_spec.rb
+++ b/spec/features/log_in_spec.rb
@@ -1,9 +1,9 @@
-# this requires a log out to be a full test
+feature 'Log in' do
 
-feature 'logging in' do
-  scenario 'user tries to log in' do
+  scenario 'User can log in' do
     visit '/'
     add_first_user_and_confirm
+    click_link 'Sign Out'
 
     click_link 'Login'
     fill_in :handle, with: 'Lazy'
@@ -11,18 +11,17 @@ feature 'logging in' do
     click_button 'Submit'
 
     expect(page).to have_content('Hello, Samir')
-    # expect(current_path).to be('/')
-    # probably lead to membership page
   end
 
   scenario 'does not allow user to login with incorrect details' do
     visit '/'
     add_first_user_and_confirm
+    click_link 'Sign Out'
 
     click_link 'Login'
-    fill_in :handle, with: 'Lazy'
+    fill_in :handle, with: 'Lazy2'
     fill_in :password, with: 'password2'
-    expect(page).to have_content('Incorrect details entered')
+    expect(page).to have_content('No details held')
     expect(current_path).to be('/login')
   end
 end

--- a/spec/features/show_availability_spec.rb
+++ b/spec/features/show_availability_spec.rb
@@ -1,20 +1,25 @@
 feature 'Show space availability' do
   scenario 'non-logged in users can see availability of spaces' do
     visit('/')
+    add_first_user_and_confirm
     add_first_space_and_confirm
+    add_extra_availability_and_confirm
+    click_link "Sign Out"
 
     click_link "Samir's Super Shack"
 
-    expect(page).to have_content "2018-09-10"
+    expect(page).to have_content "2018-12-10"
   end
 
   scenario 'logged in users can see availability of spaces' do
     visit ('/')
     add_first_user_and_confirm
     add_first_space_and_confirm
+    add_extra_availability_and_confirm
+    click_link 'Members Area'
 
     click_link "Samir's Super Shack"
 
-    expect(page).to have_content "2018-09-10"
+    expect(page).to have_content "2018-12-10"
   end
 end

--- a/spec/features/sign_out_spec.rb
+++ b/spec/features/sign_out_spec.rb
@@ -1,0 +1,8 @@
+feature 'Sign out' do
+  scenario 'User can sign out' do
+    visit '/'
+    add_first_user_and_confirm
+    click_link 'Sign Out'
+    expect(page).to have_content('You have signed out, see you again soon!')
+  end
+end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -10,6 +10,7 @@ feature "Sign up" do
   scenario "User can't sign up with an existing username" do
     visit "/"
     add_first_user_and_confirm
+    click_link "Sign Out"
 
     click_link "Signup"
     fill_in :name, with: "Samir"
@@ -25,6 +26,7 @@ feature "Sign up" do
   scenario "can't sign up with existing username" do
     visit "/"
     add_first_user_and_confirm
+    click_link "Sign Out"
 
     click_link "Signup"
     fill_in :name, with: "Samir"
@@ -34,6 +36,6 @@ feature "Sign up" do
     fill_in :password_confirmation, with: "password1"
     click_button "Submit"
 
-    expect(page).to have_content("Handle has already been taken")
+    expect(page).to have_content("Username has already been taken")
   end
 end

--- a/spec/web_helpers.rb
+++ b/spec/web_helpers.rb
@@ -31,9 +31,7 @@ end
 
 def add_extra_availability_and_confirm
   click_link 'Members Area'
-  click_link 'Add'
-  fill_in :user_id_2, with: '1'
-  fill_in :name_2, with: "Samir's Super Shack"
-  fill_in :date_2, with: '2018-12-10'
+  click_link "Samir's Super Shack"
+  fill_in :date, with: '2018-12-10'
   click_button 'Add New Date'
 end

--- a/spec/web_helpers.rb
+++ b/spec/web_helpers.rb
@@ -1,25 +1,21 @@
 def add_first_space_and_confirm
   click_link 'Members Area'
-  click_link 'Add'
-  fill_in :user_id, with: '1'
+  click_link 'Add New Space'
   fill_in :name, with: "Samir's Super Shack"
   fill_in :info, with: '1 room, 1 bed, not great tbh'
   fill_in :location, with: 'Middle of nowhere'
   fill_in :price, with: '1000000'
-  fill_in :date, with: '2018-09-10'
   click_button 'Add New Space'
 end
 
 
 def add_second_space_and_confirm
   click_link 'Members Area'
-  click_link 'Add'
-  fill_in :user_id, with: '2'
+  click_link 'Add New Space'
   fill_in :name, with: "Harry's Happy House"
   fill_in :info, with: '20 room, 1 bed, a work in progress'
   fill_in :location, with: 'Right here'
   fill_in :price, with: '5000'
-  fill_in :date, with: '2018-09-11'
   click_button 'Add New Space'
 end
 

--- a/views/add_form.erb
+++ b/views/add_form.erb
@@ -14,18 +14,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
           <a class="nav-link" href="/login">Login</a>
         </li>
         <li>
           <a class="nav-link" href="/signup">Signup</a>
         </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
         <li>
-          <a class="nav-link" href="/messages">Messages</a>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
         </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/add_form.erb
+++ b/views/add_form.erb
@@ -41,8 +41,6 @@
   <div>
    Add New Space
     <form action="/spaces/create" method="post">
-      <input type="text" name="user_id" required> User id
-      <br>
       <input type="text" name="name" required> Space Name
       <br>
       <input type="text" name="info" required> Info
@@ -51,25 +49,9 @@
       <br>
       <input type="text" name="price" required> Price
       <br>
-      <input type="date" name="date" required> Date Available
-      <br>
       <br>
       <input type="submit" value="Add New Space">
     </form>
   </div>
-  <br>
-  <br>
-  <div>
-    Add Date to Exisiting Space
-    <form action="/spaces/update" method="post">
-      <input type="text" name="user_id_2" required> User id
-      <br>
-      <input type="text" name="name_2" required> Space Name
-      <br>
-      <input type="date" name="date_2" required> Date
-      <br>
-      <br>
-      <input type="submit" value="Add New Date">
-    </form>
-  </div>
+
 </body>

--- a/views/index.erb
+++ b/views/index.erb
@@ -18,15 +18,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
           <a class="nav-link" href="/login">Login</a>
         </li>
         <li>
           <a class="nav-link" href="/signup">Signup</a>
         </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
+        <li>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
+        </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/login.erb
+++ b/views/login.erb
@@ -14,15 +14,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
           <a class="nav-link" href="/login">Login</a>
         </li>
         <li>
           <a class="nav-link" href="/signup">Signup</a>
         </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
+        <li>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
+        </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/login.erb
+++ b/views/login.erb
@@ -53,7 +53,7 @@
       <%= "Hello, #{session[:current_user].name}" unless session[:current_user] == nil %>
     </h1>
     <h1>
-      <%= flash[:error] %>
+      <%= flash[:notice] %>
     </h1>
   </center>
 </body>

--- a/views/members_area.erb
+++ b/views/members_area.erb
@@ -18,15 +18,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
-          <a class="nav-link" href="/add_form">Add</a>
+          <a class="nav-link" href="/login">Login</a>
+        </li>
+        <li>
+          <a class="nav-link" href="/signup">Signup</a>
+        </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
         </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
         <li>
-          <a class="nav-link" href="/messages">Messages</a>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
         </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/members_area.erb
+++ b/views/members_area.erb
@@ -44,6 +44,8 @@
   </nav>
   <br>
   <center><%= flash[:notice] %></center>
+
+<a href="/spaces/create">Add New Space</a>
   <% @space.each do |space| %>
     <ul>
       <a href='/space/<%= space.id %>'>

--- a/views/members_area.erb
+++ b/views/members_area.erb
@@ -44,6 +44,23 @@
   </nav>
   <br>
   <center><%= flash[:notice] %></center>
+  <% @space.each do |space| %>
+    <ul>
+      <a href='/space/<%= space.id %>'>
+        <%= space.name %>
+      </a>
+      </li>
+      <li>Info:
+        <%= space.info %>
+      </li>
+      <li>Location:
+        <%= space.location %>
+      </li>
+      <li>Price:
+        <%= space.price %>
+      </li>
+    </ul>
+    <% end %>
 </body>
 
 </html>

--- a/views/messages.erb
+++ b/views/messages.erb
@@ -18,12 +18,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
+        <li>
+          <a class="nav-link" href="/login">Login</a>
+        </li>
+        <li>
+          <a class="nav-link" href="/signup">Signup</a>
+        </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
         <li>
-          <a class="nav-link" href="/messages">Messages</a>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
         </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/signup.erb
+++ b/views/signup.erb
@@ -14,15 +14,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
           <a class="nav-link" href="/login">Login</a>
         </li>
         <li>
           <a class="nav-link" href="/signup">Signup</a>
         </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
+        <li>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
+        </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/signup.erb
+++ b/views/signup.erb
@@ -38,7 +38,9 @@
       </ul>
     </div>
   </nav>
-
+  <center>
+    <%= flash[:notice] %>
+  </center>
   <form action="/signup" method="post">
     <input type="text" name="name" required> Name
     <br>
@@ -54,8 +56,6 @@
     <input type="submit" value="Submit">
   </form>
 
-  <center>
-    <%= flash[:notice] %>
-  </center>
+
 
 </body>

--- a/views/signup.erb
+++ b/views/signup.erb
@@ -55,8 +55,7 @@
   </form>
 
   <center>
-    <%= flash[:success] %>
-    <%= flash[:error] %>
+    <%= flash[:notice] %>
   </center>
 
 </body>

--- a/views/space.erb
+++ b/views/space.erb
@@ -13,15 +13,27 @@
     </button>
     <div class="collapse navbar-collapse" id="collapsibleNavbar">
       <ul class="navbar-nav">
+        <% if session[:current_user] == nil %>
         <li>
           <a class="nav-link" href="/login">Login</a>
         </li>
         <li>
           <a class="nav-link" href="/signup">Signup</a>
         </li>
+        <% else %>
+        <li>
+          <a class="nav-link">Hello, <%= session[:current_user].handle %></a>
+        </li>
+        <li>
+          <a class="nav-link" href="/sign_out">Sign Out</a>
+        </li>
         <li>
           <a class="nav-link" href="/members_area">Members Area</a>
         </li>
+        <li>
+          <a class="nav-link" href="/members_area/messages">Messages</a>
+        </li>
+        <% end %>
       </ul>
     </div>
   </nav>

--- a/views/space.erb
+++ b/views/space.erb
@@ -41,24 +41,21 @@
     Available dates for
     <%= @space.name %>
   </h1>
-  <br>
+  <%= flash[:notice] %>
   <br>
   <% @available_dates.each do |a| %>
     <%= a %>
       <br>
       <br>
   <% end %>
-      <br>
-      <br>
       <% if @real_owner %>
       <!--  if session[:current_user] is same as user id owner of space -->
       Add Date to Space
       <form action="/spaces/update" method="post">
-        <input type="date" name="date" required> Date
+        <input type="date" name="date" required>
         <br>
         <br>
         <input type="submit" value="Add New Date">
       </form>
       <% end %>
-      <%= flash[:notice] %>
 </body>

--- a/views/space.erb
+++ b/views/space.erb
@@ -43,16 +43,15 @@
   </h1>
   <br>
   <br>
-
   <% @available_dates.each do |a| %>
     <%= a %>
       <br>
       <br>
   <% end %>
-
       <br>
       <br>
-      <% if session[:current_user] != nil %>
+      <% if @real_owner %>
+      <!--  if session[:current_user] is same as user id owner of space -->
       Add Date to Space
       <form action="/spaces/update" method="post">
         <input type="date" name="date" required> Date

--- a/views/space.erb
+++ b/views/space.erb
@@ -48,14 +48,18 @@
     <%= a %>
       <br>
       <br>
-      <% end %>
+  <% end %>
 
+      <br>
+      <br>
+      <% if session[:current_user] != nil %>
+      Add Date to Space
+      <form action="/spaces/update" method="post">
+        <input type="date" name="date" required> Date
         <br>
         <br>
-        <form action="/spaces" method="get">
-          <input type="submit" value="Back">
-        </form>
-        <form action="/" method="get">
-          <input type="submit" value="Home">
-        </form>
+        <input type="submit" value="Add New Date">
+      </form>
+      <% end %>
+      <%= flash[:notice] %>
 </body>


### PR DESCRIPTION
Okay, so this went a little bit beyond the Nav bar. 

- Made certain Nav bar segments only visible when logged on/off. 
- Loads of feature test changes. 
- Loads of fixed functionality through changing feature tests. e.g. can't sign up twice with same details.
- Member page now holds add space + displays all spaces owned by user.
- Individual space pages can be accessed via home page or members area. In both cases, if the user is logged in and owns the space being viewed, they will be able to be able to add extra availability from page. If not, the user will not see this option. 

Only failing tests or non-coverage areas are with the User unit tests. We get those tomorrow.

Oh, we also need to figure out this database instructions thing. How do we get the details to Ed? Also, do we need a local db for tests?